### PR TITLE
fix(OriginCode): fix origin code extractor, fix parent reference erro…

### DIFF
--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -2,3 +2,7 @@ If you're using @racgoo/scry for tracing in the browser, the results will be pri
 Each output includes a link — simply click it to view the trace results in a new tab.
 
 For a more detailed explanation, take a look at the `App.tsx` file.
+
+1. npm install at root library directory
+2. npm install at example/browser directoy
+3. npm run dev_reload

--- a/examples/browser/src/App.tsx
+++ b/examples/browser/src/App.tsx
@@ -2,15 +2,17 @@ import reactLogo from "./assets/react.svg";
 import viteLogo from "/vite.svg";
 import "./App.css";
 import { Tracer } from "@racgoo/scry";
-import { asyncTest, syncTest } from "./test";
+import { asyncTest, classTest, syncTest } from "./test";
 
 function App() {
   function handleClick() {
     Tracer.start();
-    asyncTest();
     syncTest();
+    asyncTest();
+    classTest();
     Tracer.end();
   }
+
   return (
     <>
       <div style={{ display: "flex", gap: "10px" }}>

--- a/examples/nodejs/README.md
+++ b/examples/nodejs/README.md
@@ -3,3 +3,7 @@ You can view the results by opening the generated HTML file in your browser.
 To see the latest tracing results, simply refresh the browser tab that has the file open.
 
 For more details, please refer to `index.js`.
+
+1. npm install at root library directory
+2. npm install at example/nodejs directoy
+3. npm run dev_reload

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "nodetest",
   "version": "1.0.0",
   "main": "src/index.js",
-  "type": "module",
+  "type": "commonjs",
   "scripts": {
     "start": "npm run build && node dist/index.js",
     "dev_reload": "npm run reload && npm run build && node dist/index.js",

--- a/examples/nodejs/src/cjs-test.js
+++ b/examples/nodejs/src/cjs-test.js
@@ -1,5 +1,4 @@
-async function asyncTest1(flag: string) {
-  console.log("asyncTest", flag);
+async function asyncTest1(flag) {
   await asyncTest2(flag + ":await1");
   asyncTest2(flag + ":then1").then((res) => {
     console.log(res);
@@ -9,11 +8,11 @@ async function asyncTest1(flag: string) {
   return flag + "bye..";
 }
 
-async function asyncTest2(flag: string) {
+async function asyncTest2(flag) {
   return new Promise((resolve) => setTimeout(() => resolve(flag), 1000));
 }
 
-export async function asyncTest() {
+async function asyncTest() {
   asyncTest1("then1").then((res) => {
     console.log(res);
   });
@@ -31,7 +30,7 @@ const syncTest2 = () => {
   console.log("syncTest2");
 };
 
-export const syncTest = () => {
+const syncTest = () => {
   syncTest1();
   syncTest2();
 };
@@ -43,7 +42,13 @@ class TestClass {
   }
 }
 
-export const classTest = () => {
+const classTest = () => {
   const testInstance = new TestClass();
   testInstance.test();
+};
+
+module.exports = {
+  asyncTest,
+  syncTest,
+  classTest,
 };

--- a/examples/nodejs/src/index.js
+++ b/examples/nodejs/src/index.js
@@ -1,47 +1,12 @@
 //ESM
 import { Tracer } from "@racgoo/scry";
+import { classTest, asyncTest, syncTest } from "./mjs-test.js";
 //CJS
 // const { Tracer } = require("@racgoo/scry");
-
-async function asyncTest1(flag) {
-  console.log("asyncTest", flag);
-  await asyncTest2(flag + ":await1");
-  asyncTest2(flag + ":then1").then((res) => {
-    console.log(res);
-  });
-  await asyncTest2(flag + ":await2");
-  console.log("alldone");
-  return flag + "bye..";
-}
-
-async function asyncTest2(flag) {
-  return new Promise((resolve) => setTimeout(() => resolve(flag), 1000));
-}
-
-async function asyncTest() {
-  asyncTest1("then1").then((res) => {
-    console.log(res);
-  });
-  await asyncTest1("await1");
-  asyncTest1("then2").then((res) => {
-    console.log(res);
-  });
-  await asyncTest1("await2");
-}
-
-const syncTest1 = () => {
-  console.log("syncTest1");
-};
-const syncTest2 = () => {
-  console.log("syncTest2");
-};
-
-const syncTest = () => {
-  syncTest1();
-  syncTest2();
-};
+// const { classTest, asyncTest, syncTest } = require("./cjs-test.js");
 
 Tracer.start();
 asyncTest();
 syncTest();
+classTest();
 Tracer.end();

--- a/examples/nodejs/src/mjs-test.js
+++ b/examples/nodejs/src/mjs-test.js
@@ -1,5 +1,4 @@
-async function asyncTest1(flag: string) {
-  console.log("asyncTest", flag);
+async function asyncTest1(flag) {
   await asyncTest2(flag + ":await1");
   asyncTest2(flag + ":then1").then((res) => {
     console.log(res);
@@ -9,7 +8,7 @@ async function asyncTest1(flag: string) {
   return flag + "bye..";
 }
 
-async function asyncTest2(flag: string) {
+async function asyncTest2(flag) {
   return new Promise((resolve) => setTimeout(() => resolve(flag), 1000));
 }
 

--- a/src/babel/scry-babel-plugin.ts
+++ b/src/babel/scry-babel-plugin.ts
@@ -8,7 +8,6 @@ function scryBabelPlugin(
   type: "cjs" | "esm" //Output type
 ) {
   //Pre process for origin code comment(but it must be done in visitor)
-  const esm = type === "esm";
   const pre = function (this: babel.PluginPass) {
     if (ScryChecker.isNodeModule(this)) return;
     try {
@@ -32,6 +31,33 @@ function scryBabelPlugin(
               scryAst.preProcess(path, scryAst, scryChecker, code);
             } catch (error) {
               console.error("pre process ClassDeclaration error:", error);
+            }
+          },
+          ClassMethod(path) {
+            //Pre process for origin code as string
+            try {
+              scryAst.preProcess(path, scryAst, scryChecker, code);
+            } catch (error) {
+              console.error("pre process ClassMethod error:", error);
+            }
+          },
+          ObjectMethod(path) {
+            //Pre process for origin code as string
+            try {
+              scryAst.preProcess(path, scryAst, scryChecker, code);
+            } catch (error) {
+              console.error("pre process ObjectMethod error:", error);
+            }
+          },
+          ArrowFunctionExpression(path) {
+            //Pre process for origin code as string
+            try {
+              scryAst.preProcess(path, scryAst, scryChecker, code);
+            } catch (error) {
+              console.error(
+                "pre process ArrowFunctionExpression error:",
+                error
+              );
             }
           },
         });
@@ -211,7 +237,7 @@ function scryBabelPlugin(
           //Create parent traceId optional updater(for async/await)
           scryAst.createParentTraceIdOptionalUpdater(path),
           //Extract code from location
-          scryAst.createCodeExtractor(),
+          scryAst.createCodeExtractor(path),
           //Generate 'enter' event
           t.expressionStatement(
             scryAst.emitTraceEvent(

--- a/src/babel/scry.check.ts
+++ b/src/babel/scry.check.ts
@@ -179,7 +179,6 @@ class ScryChecker {
         path.node.callee.object.name === "process")
     );
   }
-
   //Check if the function is a JSX function
   public isJSX(
     path: babel.NodePath<babel.types.CallExpression | babel.types.NewExpression>

--- a/src/babel/scry.constant.ts
+++ b/src/babel/scry.constant.ts
@@ -16,6 +16,10 @@ export const TRACE_ZONE = "__TRACE_ZONE__";
 export const ACTIVE_TRACE_ID_SET = "__ACTIVE_TRACE_ID_SET__";
 //Marker for parent trace id declare
 export const PARENT_TRACE_ID_MARKER = "__PARENT_TRACE_ID_MARK__";
+//Marker for origin code start
+export const ORIGINAL_CODE_START_MARKER = "__ORIGINAL_CODE_START_MARK__";
+//Marker for origin code end
+export const ORIGINAL_CODE_END_MARKER = "__ORIGINAL_CODE_END_MARK__";
 
 //Event type for trace event
 export const ScryEventType = {

--- a/src/utils/extractor.ts
+++ b/src/utils/extractor.ts
@@ -1,45 +1,64 @@
 import path from "path";
 import fs from "fs";
+import {
+  ORIGINAL_CODE_END_MARKER,
+  ORIGINAL_CODE_START_MARKER,
+} from "../babel/scry.constant.js";
 
 //Extract code from instance and method(Runtime Extractor)
 class Extractor {
   constructor() {}
 
+  //ExtractOriginCode
+  private static extractOriginCode(tranfiledCode: string): string {
+    const originCode = tranfiledCode
+      ?.split(ORIGINAL_CODE_START_MARKER)[1]
+      ?.split(ORIGINAL_CODE_END_MARKER)[0];
+    if (originCode) {
+      return originCode.replace(/\\n/g, "\n");
+    } else {
+      return "[External Code]";
+    }
+  }
+
   //Extract code from instance and method(if it's not method, extract function code)
   public static extractCode(
-    instance: { [key: string]: unknown },
-    method: string
+    instance: { [key: string]: unknown } | null,
+    method: string | null,
+    func: typeof Function | null
   ) {
     const result = {
       functionCode: "",
       classCode: "",
       methodCode: "",
     };
-    if (!this.isMethod(instance, method)) {
-      result.functionCode = this.extractFunction(
-        instance[method] as typeof Function
-      ).functionCode;
-    } else {
-      result.classCode = instance.constructor.toString();
-      result.methodCode =
-        instance.constructor.prototype[method]?.toString() ?? "";
+    if (func) {
+      result.functionCode = this.extractOriginCode(func.toString());
     }
+    if (this.isMethod(instance, method)) {
+      result.classCode = this.extractOriginCode(
+        instance!.constructor.toString()
+      );
+      result.methodCode = this.extractOriginCode(
+        instance!.constructor.prototype[method!]?.toString() ?? ""
+      );
+    }
+
     return result;
   }
+
   //Check if the function is a method
-  private static isMethod(instance: object, funcName: string) {
-    if (instance.constructor.prototype[funcName]) {
+  private static isMethod(
+    instance: { [key: string]: unknown } | null,
+    method: string | null
+  ) {
+    if (!instance || !method) {
+      return false;
+    }
+    if (instance.constructor.prototype[method]) {
       return true;
     }
     return false;
-  }
-  //Extract function code
-  static extractFunction(func: typeof Function) {
-    return {
-      functionCode: func?.toString() ?? "Cannot extract function code",
-      classCode: "",
-      methodCode: "",
-    };
   }
 
   //Find nearest package.json file


### PR DESCRIPTION
1.  Fix Origin Code Extractor
- add origin code as string expression. 
- in runtime, Object.toString() method can extract transfiled code and extract origin call string
2. Format Error
- fix UI formatter children drilling

sorry, I was busy.
don't worry! scry never stop upgrading.