### PR TITLE
fix: bundle zone.js via @racgoo/scry/zone to fix Vite resolution error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "./babel": {
       "import": "./dist/esm/babel/index.js",
       "require": "./dist/cjs/babel/index.cjs"
+    },
+    "./zone": {
+      "import": "./dist/esm/zone-init.js",
+      "require": "./dist/cjs/zone-init.cjs"
     }
   },
   "repository": {

--- a/src/babel/scry.ast.ts
+++ b/src/babel/scry.ast.ts
@@ -383,30 +383,38 @@ class ScryAst {
   }
 
   //Add Zone.js import or require statement(on Program level)
+  // Injects `@racgoo/scry/zone` instead of bare `zone.js` so that zone.js is
+  // resolved from scry's own node_modules, not from the consumer project root.
+  // This prevents "Failed to resolve import zone.js" in tools like Vite that
+  // resolve bare specifiers relative to the file that contains the import.
   public createZoneJSDeclaration(
     path: babel.NodePath<babel.types.Program>,
     esm: boolean
   ) {
     const scryChecker = new ScryChecker(this.t);
-    const zoneJSImported = scryChecker.isImportedWithoutVariableDeclaration(
-      path,
-      "zone.js",
-      esm
-    );
+    // Skip if the user already imported zone.js (bare or via scry/zone)
+    const zoneJSImported =
+      scryChecker.isImportedWithoutVariableDeclaration(path, "zone.js", esm) ||
+      scryChecker.isImportedWithoutVariableDeclaration(
+        path,
+        "@racgoo/scry/zone",
+        esm
+      );
     if (zoneJSImported) {
       return;
     }
     if (esm) {
-      //For esm target
       path.node.body.unshift(
-        this.t.importDeclaration([], this.t.stringLiteral("zone.js"))
+        this.t.importDeclaration(
+          [],
+          this.t.stringLiteral("@racgoo/scry/zone")
+        )
       );
     } else {
-      //For commonjs target
       path.node.body.unshift(
         this.t.expressionStatement(
           this.t.callExpression(this.t.identifier("require"), [
-            this.t.stringLiteral("zone.js/mix"),
+            this.t.stringLiteral("@racgoo/scry/zone"),
           ])
         )
       );

--- a/src/zone-init.ts
+++ b/src/zone-init.ts
@@ -1,0 +1,4 @@
+// Re-exports zone.js so the babel plugin can inject `import "@racgoo/scry/zone"`
+// instead of `import "zone.js"`. This keeps zone.js resolution inside scry's
+// own node_modules, preventing "Cannot resolve zone.js" errors in consumer projects.
+import "zone.js";


### PR DESCRIPTION
## 문제

babel 플러그인이 사용자 소스 파일에 `import "zone.js"`를 직접 주입했습니다.  
Vite는 bare specifier를 **해당 파일 위치 기준**으로 resolve하기 때문에, 사용자 프로젝트의 `node_modules`에서 `zone.js`를 찾으려 했고, 설치되어 있지 않아 아래 오류가 발생했습니다.

```
[plugin:vite:import-analysis] Failed to resolve import "zone.js" from "src/main.tsx"
```

## 수정 내용

| 파일 | 변경 사항 |
|------|-----------|
| `src/zone-init.ts` | `import "zone.js"` 프록시 파일 신규 생성 |
| `package.json` | `"./zone"` 익스포트 추가 (`dist/esm/zone-init.js` / `dist/cjs/zone-init.cjs`) |
| `src/babel/scry.ast.ts` | 주입 경로를 `zone.js` → `@racgoo/scry/zone` 으로 변경 |

## 동작 원리

`import "@racgoo/scry/zone"`으로 변경하면 Vite가 scry 패키지의 exports map을 따라 `dist/esm/zone-init.js`를 열고, **그 파일의 위치(scry 패키지 내부)** 기준으로 `zone.js`를 resolve합니다.  
zone.js는 scry의 `dependencies`에 선언되어 있으므로 항상 존재합니다.

## Test plan

- [ ] `pnpm run pack` → 생성된 `.tgz`를 다른 프로젝트에 설치
- [ ] Vite dev server 실행 시 `zone.js` 관련 오류 없음 확인
- [ ] 트레이싱이 정상 동작하는지 확인

Made with [Cursor](https://cursor.com)