### PR TITLE
fix: resolve 11 bugs across tracer, babel plugin, and utilities

### DIFF
--- a/src/babel/scry-babel-plugin.ts
+++ b/src/babel/scry-babel-plugin.ts
@@ -201,6 +201,8 @@ function scryBabelPlugin(
         state: babel.PluginPass
       ) {
         try {
+          const filename = state.filename ?? "";
+          if (!isFileIncluded(filename, options)) return;
           transformCall(path, state, t, scryAst, scryChecker, maxDepth);
         } catch (error) {
           console.error("NewExpression.exit error:", error);

--- a/src/babel/scry.ast.ts
+++ b/src/babel/scry.ast.ts
@@ -230,6 +230,10 @@ class ScryAst {
         ),
       ]);
     } else {
+      // callee can be Identifier, CallExpression, ArrowFunctionExpression, etc.
+      // We pass it as-is (any Expression evaluates to the function at runtime).
+      // The previous cast to Identifier was incorrect for non-identifier callees
+      // such as IIFEs or higher-order calls like getFunc()().
       return this.t.variableDeclaration("const", [
         this.t.variableDeclarator(
           this.t.identifier("code"),
@@ -241,8 +245,7 @@ class ScryAst {
             [
               this.t.nullLiteral(),
               this.t.nullLiteral(),
-              // this.t.stringLiteral(originCode),
-              callee as babel.types.Identifier,
+              callee as babel.types.Expression,
             ]
           )
         ),
@@ -859,7 +862,49 @@ class ScryAst {
                             ),
                             this.t.identifier("then")
                           ),
+                          // Pass both onFulfilled and onRejected so that a rejected
+                          // Promise still emits the done event and cleans up
+                          // activeTraceIdSet. Without onRejected, rejected Promises
+                          // would leave the traceId in activeTraceIdSet indefinitely
+                          // (until the waitAllContextDone timeout fires).
                           [
+                            this.t.arrowFunctionExpression(
+                              [],
+                              this.t.blockStatement([
+                                this.t.variableDeclaration("let", [
+                                  this.t.variableDeclarator(
+                                    this.t.identifier(
+                                      ScryAstVariable.traceContext
+                                    ),
+                                    this.t.memberExpression(
+                                      this.t.memberExpression(
+                                        this.t.memberExpression(
+                                          this.t.identifier("Zone"),
+                                          this.t.identifier("current")
+                                        ),
+                                        this.t.identifier(
+                                          ScryAstVariable._properties
+                                        )
+                                      ),
+                                      this.t.stringLiteral(
+                                        ScryAstVariable.traceContext
+                                      ),
+                                      true
+                                    )
+                                  ),
+                                ]),
+                                this.t.expressionStatement(
+                                  this.emitTraceEvent(
+                                    this.getEventDetail(path, state, {
+                                      type: "done",
+                                      fnName: this.getFunctionName(path),
+                                      chained: false,
+                                    })
+                                  )
+                                ),
+                              ])
+                            ),
+                            // onRejected: emit done even when the Promise rejects
                             this.t.arrowFunctionExpression(
                               [],
                               this.t.blockStatement([

--- a/src/babel/scry.check.ts
+++ b/src/babel/scry.check.ts
@@ -100,7 +100,14 @@ class ScryChecker {
               ) {
                 return true;
               }
-              if (decl.id.type === "Identifier") {
+              // Identifier case: `const Tracer = require("@racgoo/scry")`
+              // The binding name must match `name` — the previous code returned
+              // true for ANY identifier binding regardless of what name was used,
+              // causing false-positive "already imported" results.
+              if (
+                decl.id.type === "Identifier" &&
+                decl.id.name === name
+              ) {
                 return true;
               }
             }
@@ -295,20 +302,22 @@ class ScryChecker {
     );
   }
 
-  //Check if the function is a nodejs process method
+  // Skip instrumentation only for process.on / process.emit which directly
+  // interact with the Node.js event loop and can cause infinite recursion when
+  // wrapped in a Zone-forking IIFE. Other process.* calls (e.g. process.cwd(),
+  // process.exit()) are safe to trace and were unintentionally excluded by the
+  // previous overly-broad second OR branch.
   public isNodejsProcessMethod(
     path: babel.NodePath<babel.types.CallExpression | babel.types.NewExpression>
   ) {
     return (
-      (this.t.isMemberExpression(path.node.callee) &&
-        this.t.isIdentifier(path.node.callee.object) &&
-        path.node.callee.object.name === "process" &&
-        this.t.isIdentifier(path.node.callee.property) &&
-        ["on", "emit"].includes(path.node.callee.property.name)) ||
-      //Check if the function is a process function
-      (this.t.isMemberExpression(path.node.callee) &&
-        this.t.isIdentifier(path.node.callee.object) &&
-        path.node.callee.object.name === "process")
+      this.t.isMemberExpression(path.node.callee) &&
+      this.t.isIdentifier(path.node.callee.object) &&
+      path.node.callee.object.name === "process" &&
+      this.t.isIdentifier(path.node.callee.property) &&
+      ["on", "emit", "nextTick", "addListener", "removeListener"].includes(
+        path.node.callee.property.name
+      )
     );
   }
   //Check if the function is a JSX function

--- a/src/tracer/node/nodeGenerator.ts
+++ b/src/tracer/node/nodeGenerator.ts
@@ -176,7 +176,7 @@ class NodeGenerator {
     reversedChainedTraceIdGroups: number[][]
   ) {
     //Iterate reversedChainedTraceIdGroups for updating trace node map state
-    reversedChainedTraceIdGroups.some((reversedChainedTraceIdGroup) => {
+    reversedChainedTraceIdGroups.forEach((reversedChainedTraceIdGroup) => {
       //Chain root parent trace id(first chained trace's parent trace id)
       const rootParentTraceId = traceNodeMap.get(
         reversedChainedTraceIdGroup[0]
@@ -210,27 +210,24 @@ class NodeGenerator {
     //Create new trace node map, because, Map is ordered by insertion order
     const newTraceNodeMap = new Map<number, TraceNode>();
     //Sort and update newTraceNodeMap
+    // Single comparator: primary key = traceId, secondary key = chainInfo.index
+    // (within the same chain group). Two separate .sort() calls were used before,
+    // but chaining sorts is unreliable — the second sort can disturb the first
+    // sort's order for elements that compare equal.
     Array.from(traceNodeMap.values())
-      //Sort by trace id(sort by trace id, because trace id sort must be first srt)
       .sort((a, b) => {
-        if (a.traceId && b.traceId) {
-          return a.traceId - b.traceId;
+        const traceIdDiff = (a.traceId ?? 0) - (b.traceId ?? 0);
+        if (traceIdDiff !== 0) return traceIdDiff;
+        if (
+          a.chainInfo &&
+          b.chainInfo &&
+          a.chainInfo.startTraceId === b.chainInfo.startTraceId
+        ) {
+          return a.chainInfo.index - b.chainInfo.index;
         }
         return 0;
       })
-      //Sort by chain index(chained sort must be second sort)
-      //must be chain node, when same start trace id, sort by chain index
-      //
-      .sort((a, b) => {
-        if (a.chainInfo && b.chainInfo) {
-          if (a.chainInfo.startTraceId === b.chainInfo.startTraceId) {
-            return a.chainInfo.index - b.chainInfo.index;
-          }
-        }
-        return 0;
-      })
-      .some((node) => {
-        //insert sorted node to newTraceNodeMap
+      .forEach((node) => {
         newTraceNodeMap.set(node.traceId, node);
       });
     return newTraceNodeMap;

--- a/src/tracer/node/type.d.ts
+++ b/src/tracer/node/type.d.ts
@@ -20,7 +20,7 @@ interface TraceNode {
   errored: boolean;
   completed: boolean;
   chained?: boolean;
-  parentTraceId?: number;
+  parentTraceId?: number | null;
   classCode?: string;
   methodCode?: string;
   functionCode?: string;

--- a/src/tracer/record/type.ts
+++ b/src/tracer/record/type.ts
@@ -26,7 +26,7 @@ interface TraceDetail {
   source: string;
   args: unknown[];
   traceBundleId: number;
-  parentTraceId: number;
+  parentTraceId: number | null;
   returnValue: unknown;
   classCode: string;
   methodCode: string;

--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -74,29 +74,33 @@ class Tracer {
     //in Object, return value is resolved automatically when context is done
     const asyncTaskLoading = this.recorder.waitAllContextDone(endBundleId);
     //Wait for all return values to be resolved
-    asyncTaskLoading.then(async () => {
-      //Get current bundle details
-      const currentBundleDetails =
-        this.recorder.getBundleMap().get(endBundleId)?.details || [];
-      //Make trace tree(hierarchical tree structure by call)
-      const traceNodes: TraceNode[] =
-        this.nodeGenerator.generateNodesWithTraceDetails(currentBundleDetails);
-      //Update duration
-      this.recorder.getBundleMap().get(endBundleId)!.duration = dayjs().diff(
-        this.recorder.getBundleMap().get(endBundleId)!.startTime,
-        "ms"
-      );
+    asyncTaskLoading
+      .then(async () => {
+        //Get current bundle details
+        const currentBundleDetails =
+          this.recorder.getBundleMap().get(endBundleId)?.details || [];
+        //Make trace tree(hierarchical tree structure by call)
+        const traceNodes: TraceNode[] =
+          this.nodeGenerator.generateNodesWithTraceDetails(currentBundleDetails);
+        //Update duration
+        this.recorder.getBundleMap().get(endBundleId)!.duration = dayjs().diff(
+          this.recorder.getBundleMap().get(endBundleId)!.startTime,
+          "ms"
+        );
 
-      //Generate html root for Display UI(HTML)
-      const htmlRoot = Format.generateHtmlRoot(
-        this.recorder.getBundleMap().get(endBundleId)!.description,
-        traceNodes,
-        this.recorder.getBundleMap().get(endBundleId)!.startTime,
-        this.recorder.getBundleMap().get(endBundleId)!.duration
-      );
-      //Export html
-      this.exporter.exportToHtml(htmlRoot);
-    });
+        //Generate html root for Display UI(HTML)
+        const htmlRoot = Format.generateHtmlRoot(
+          this.recorder.getBundleMap().get(endBundleId)!.description,
+          traceNodes,
+          this.recorder.getBundleMap().get(endBundleId)!.startTime,
+          this.recorder.getBundleMap().get(endBundleId)!.duration
+        );
+        //Export html
+        this.exporter.exportToHtml(htmlRoot);
+      })
+      .catch((error) => {
+        Output.printError(`Tracer.end() failed to generate report: ${error}`);
+      });
   }
 
   private handleDuplicatedStart() {

--- a/src/tracer/zone/zoneContext.ts
+++ b/src/tracer/zone/zoneContext.ts
@@ -7,34 +7,30 @@ class ZoneContext implements ZoneContextInterface {
    * Zone.current is used for function-level execution context, while Zone.root is used for file-level execution
    * This ensures that subsequent logic tracks based on the updated state
    */
+  // Safely access or initialise _properties.traceContext on a Zone instance.
+  // Zone.root._properties starts as {} — traceContext is injected by the babel
+  // plugin at Program.enter, but Tracer.start() / Tracer.end() can be called
+  // before any instrumented file runs (e.g. in test setup), so we must guard.
+  private ensureTraceContext(zone: Zone) {
+    const props = (zone as unknown as { _properties: Record<string, unknown> })
+      ._properties;
+    if (!props.traceContext) {
+      props.traceContext = { traceBundleId: null, parentTraceId: null };
+    }
+    return props.traceContext as {
+      traceBundleId: number | null;
+      parentTraceId: number | null;
+    };
+  }
+
   public updateCurrentAndRootZoneBundleId(bundleId: number | null) {
-    //Update current zone state
-    (
-      Zone.current as unknown as {
-        _properties: { traceContext: { traceBundleId: number | null } };
-      }
-    )._properties.traceContext.traceBundleId = bundleId;
-    //Update root zone state
-    (
-      Zone.root as unknown as {
-        _properties: { traceContext: { traceBundleId: number | null } };
-      }
-    )._properties.traceContext.traceBundleId = bundleId;
+    this.ensureTraceContext(Zone.current).traceBundleId = bundleId;
+    this.ensureTraceContext(Zone.root).traceBundleId = bundleId;
   }
 
   public updateCurrentAndRootZoneParentTraceId(parentTraceId: number | null) {
-    //Update current zone state
-    (
-      Zone.current as unknown as {
-        _properties: { traceContext: { parentTraceId: number | null } };
-      }
-    )._properties.traceContext.parentTraceId = parentTraceId;
-    //Update root zone state
-    (
-      Zone.root as unknown as {
-        _properties: { traceContext: { parentTraceId: number | null } };
-      }
-    )._properties.traceContext.parentTraceId = parentTraceId;
+    this.ensureTraceContext(Zone.current).parentTraceId = parentTraceId;
+    this.ensureTraceContext(Zone.root).parentTraceId = parentTraceId;
   }
 }
 

--- a/src/utils/extractor.ts
+++ b/src/utils/extractor.ts
@@ -46,12 +46,27 @@ class Extractor {
       methodCode: "",
     };
 
+    // func and isMethod are mutually exclusive in generated code:
+    // - member-expression calls pass (instance, methodName, null)
+    // - standalone calls pass (null, null, funcRef)
+    // Guard both paths independently so a future call pattern that passes all
+    // three arguments doesn't cause the early-return from functionCache to skip
+    // the method-info population.
     if (func) {
       if (this.functionCache.has(func as object)) {
-        return this.functionCache.get(func as object)!;
+        const cached = this.functionCache.get(func as object)!;
+        // If this same call also provides method info, merge it in rather than
+        // returning the cached (method-less) result immediately.
+        if (!this.isMethod(instance, method)) {
+          return cached;
+        }
+        result.functionCode = cached.functionCode;
+      } else {
+        result.functionCode = this.extractOriginCode(
+          (func as unknown as { toString(): string }).toString()
+        );
+        this.functionCache.set(func as object, result);
       }
-      result.functionCode = this.extractOriginCode((func as unknown as { toString(): string }).toString());
-      this.functionCache.set(func as object, result);
     }
 
     if (this.isMethod(instance, method)) {
@@ -63,7 +78,11 @@ class Extractor {
         instance!.constructor.toString()
       );
       result.methodCode = this.extractOriginCode(
-        (instance!.constructor as { prototype: Record<string, { toString(): string }> }).prototype[method!]?.toString() ?? ""
+        (
+          instance!.constructor as {
+            prototype: Record<string, { toString(): string }>;
+          }
+        ).prototype[method!]?.toString() ?? ""
       );
       this.methodCache.set(ctor, result);
     }


### PR DESCRIPTION
## Summary

코드베이스 전체를 분석해 발견한 버그 11개를 수정했습니다.

### 🔴 Critical

| 파일 | 버그 | 수정 |
|------|------|------|
| `nodeGenerator.ts` | `.some()` 오사용 — `Map.set()`이 truthy를 반환해 **첫 번째 노드만** `newTraceNodeMap`에 삽입, 트레이스 리포트가 거의 빈 화면으로 렌더링됨 | `.forEach()`로 교체, 이중 sort도 단일 비교자로 통합 |

### 🟠 High

| 파일 | 버그 | 수정 |
|------|------|------|
| `scry-babel-plugin.ts` | `NewExpression.exit`에 `isFileIncluded` 가드 누락 → node_modules의 `new` 표현식도 계측됨 | `CallExpression`과 동일하게 파일 필터 추가 |
| `scry.ast.ts` | non-Identifier callee (IIFE, HOF 결과 등)를 `Identifier`로 잘못 캐스팅 | `Expression`으로 수정 |

### 🟡 Medium

| 파일 | 버그 | 수정 |
|------|------|------|
| `scry.ast.ts` | Promise reject 시 `done` 이벤트 미발행 → `activeTraceIdSet` 타임아웃까지 대기 | `.then(onFulfill, onReject)` 두 번째 콜백 추가 |
| `scry.check.ts` | `isNodejsProcessMethod`가 `process.*` 전체를 제외 → `process.cwd()` 등 무해한 호출도 계측 안됨 | `on/emit/nextTick/addListener/removeListener`만 제외로 축소 |
| `scry.check.ts` | CJS `isImported` Identifier 분기가 바인딩 이름 확인 안 함 → 잘못된 "이미 import됨" 판정 | `decl.id.name === name` 조건 추가 |
| `tracer.ts` | `end()` 체인에 `.catch` 없음 → 리포트 생성 실패 시 unhandled rejection | `.catch(error => Output.printError(...))` 추가 |
| `zoneContext.ts` | `Tracer.start()` 호출 시 `Zone._properties.traceContext`가 없으면 TypeError | `ensureTraceContext()` 가드 메서드 추가 |

### 🟢 Low

| 파일 | 버그 | 수정 |
|------|------|------|
| `type.ts` / `type.d.ts` | `parentTraceId: number` — 실제로는 `null`이 흐름 | `number \| null`로 수정 |
| `extractor.ts` | `functionCache` 히트 후 조기 반환으로 method 정보 누락 가능 | 분기 구조 개선, 두 경로 독립적으로 처리 |

## Test plan

- [ ] `pnpm run build` 성공 확인
- [ ] 트레이스 리포트에 전체 노드가 표시되는지 확인 (Critical #1 수정 검증)
- [ ] node_modules에서 `new`가 호출되는 라이브러리와 함께 빌드했을 때 정상 동작 확인
- [ ] async 함수에서 Promise reject 발생 시 `Tracer.end()` 정상 완료 확인
- [ ] `Tracer.start()`를 instrumented 파일 실행 전에 호출해도 crash 없는지 확인

Made with [Cursor](https://cursor.com)