### PR TITLE
docs: clarify agent owns all git operations

### DIFF
--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,9 +1,12 @@
 ---
-description: Git 커밋, push, PR 자동화 규칙
+description: Git 커밋, push, PR 자동화 규칙. 사용자는 PR 병합 + 프롬프트만 한다. 에이전트가 브랜치 생성 → 커밋 → PR 생성까지 모든 git 작업을 자동 수행한다.
 alwaysApply: true
 ---
 
 # Git & PR Workflow
+
+> **원칙**: 사용자는 PR 병합과 프롬프트만 한다. 에이전트가 모든 git 작업을 처리한다.
+> 작업 완료 후 반드시 브랜치 생성 → 커밋 → push → PR 생성 순서를 자동 수행할 것.
 
 ## 브랜치 전략 (GitFlow Lite)
 


### PR DESCRIPTION
## Summary

- 사용자는 **PR 병합 + 프롬프트만** 한다는 원칙을 rule 최상단에 명시
- git-workflow.mdc description을 업데이트해 에이전트가 파일을 열기 전에 바로 이 원칙을 인지하도록 함

## 관련

개인 Cursor 스킬 `~/.cursor/skills/auto-pr-workflow/SKILL.md` 생성 — 모든 프로젝트에서 동일한 자동 git 워크플로우 적용

## Test plan

- [ ] 다음 작업 요청 시 에이전트가 자동으로 브랜치 생성 → 커밋 → PR 올리는지 확인

Made with [Cursor](https://cursor.com)