### PR TITLE
fix: resolve 11 more bugs — sync exceptions, Zone init, _depth, format safety

### DIFF
--- a/src/babel/scry.ast.ts
+++ b/src/babel/scry.ast.ts
@@ -316,7 +316,10 @@ class ScryAst {
     }
   }
 
-  // Add Zone.root initialization code if not initialized(on Program level)
+  // Add Zone.root initialization code if not initialized(on Program level).
+  // Uses Object.assign to MERGE into the existing _properties object rather than
+  // replacing it entirely. A full assignment wipes any internal Zone.js fields
+  // that were already stored there, breaking Zone.js runtime behaviour.
   public createZoneRootInitialization(
     path: babel.NodePath<babel.types.Program>
   ) {
@@ -332,12 +335,32 @@ class ScryAst {
               ),
               this.t.identifier(ScryAstVariable._properties)
             ),
-            this.t.objectExpression([
-              this.t.objectProperty(
-                this.t.identifier(ScryAstVariable.traceContext),
-                this.t.identifier(ScryAstVariable.traceContext)
+            // Object.assign(Zone.root._properties ?? {}, { traceContext })
+            this.t.callExpression(
+              this.t.memberExpression(
+                this.t.identifier("Object"),
+                this.t.identifier("assign")
               ),
-            ])
+              [
+                this.t.logicalExpression(
+                  "??",
+                  this.t.memberExpression(
+                    this.t.memberExpression(
+                      this.t.identifier("Zone"),
+                      this.t.identifier("root")
+                    ),
+                    this.t.identifier(ScryAstVariable._properties)
+                  ),
+                  this.t.objectExpression([])
+                ),
+                this.t.objectExpression([
+                  this.t.objectProperty(
+                    this.t.identifier(ScryAstVariable.traceContext),
+                    this.t.identifier(ScryAstVariable.traceContext)
+                  ),
+                ]),
+              ]
+            )
           )
         ),
       ])
@@ -584,6 +607,10 @@ class ScryAst {
    * Generated code:
    *   if ((Zone.current._properties?._depth ?? 0) >= maxDepth) return <originalNode>;
    */
+  // Zone.js stores fork properties at zone._properties, not as direct own
+  // properties on the zone object. The previous code read Zone.current["_depth"]
+  // which always returned undefined (the zone object has no "_depth" property),
+  // making maxDepth effectively never trigger.
   public createMaxDepthGuard(
     maxDepth: number,
     originalNode: babel.types.CallExpression | babel.types.NewExpression
@@ -593,10 +620,14 @@ class ScryAst {
         ">=",
         this.t.logicalExpression(
           "??",
+          // Zone.current._properties?.["_depth"]
           this.t.optionalMemberExpression(
             this.t.memberExpression(
-              this.t.identifier("Zone"),
-              this.t.identifier("current")
+              this.t.memberExpression(
+                this.t.identifier("Zone"),
+                this.t.identifier("current")
+              ),
+              this.t.identifier(ScryAstVariable._properties)
             ),
             this.t.stringLiteral("_depth"),
             true,
@@ -722,17 +753,23 @@ class ScryAst {
                     ])
                   ),
                   //Track Zone nesting depth so the maxDepth guard can do an O(1) check.
-                  //Inherits parent depth via Zone.current._properties?._depth ?? 0 and adds 1.
+                  //Inherits parent depth via Zone.current._properties?.["_depth"] ?? 0 and adds 1.
+                  //Must read from _properties (not Zone.current directly) because Zone.js
+                  //stores fork properties at zone._properties, not as own zone properties.
                   this.t.objectProperty(
                     this.t.identifier("_depth"),
                     this.t.binaryExpression(
                       "+",
                       this.t.logicalExpression(
                         "??",
+                        // Zone.current._properties?.["_depth"]
                         this.t.optionalMemberExpression(
                           this.t.memberExpression(
-                            this.t.identifier("Zone"),
-                            this.t.identifier("current")
+                            this.t.memberExpression(
+                              this.t.identifier("Zone"),
+                              this.t.identifier("current")
+                            ),
+                            this.t.identifier(ScryAstVariable._properties)
                           ),
                           this.t.stringLiteral("_depth"),
                           true,
@@ -987,9 +1024,12 @@ class ScryAst {
     }
     //Create try block
     const tryBlock = this.t.blockStatement([resultAst]);
-    //Create catch clause: record the error as returnValue, emit exit event for observability,
-    //clean up the Zone entry to prevent memory leak, then rethrow to preserve original call semantics.
-    //Without rethrow, user try/catch blocks around traced functions would silently swallow errors.
+    // Catch clause: on synchronous throw the Zone.run callback propagates the
+    // error here. Without explicit exit/done emissions, activeTraceIdSet keeps
+    // the traceId until the timeout fires and the trace tree shows an incomplete
+    // node with no returnValue. We emit both events before rethrowing so the
+    // tracing infrastructure always sees a matched enter→exit→done sequence.
+    const fnName = this.getFunctionName(path);
     const catchClause = this.t.catchClause(
       this.t.identifier("error"),
       this.t.blockStatement([
@@ -1000,7 +1040,45 @@ class ScryAst {
             this.t.identifier("error")
           )
         ),
-        //Clean up Zone entry on error path to prevent memory leak
+        // Re-capture traceContext from the current (parent) Zone so that
+        // traceBundleId / parentTraceId are available for the events below.
+        this.t.variableDeclaration("let", [
+          this.t.variableDeclarator(
+            this.t.identifier(ScryAstVariable.traceContext),
+            this.t.memberExpression(
+              this.t.memberExpression(
+                this.t.memberExpression(
+                  this.t.identifier("Zone"),
+                  this.t.identifier("current")
+                ),
+                this.t.identifier(ScryAstVariable._properties)
+              ),
+              this.t.stringLiteral(ScryAstVariable.traceContext),
+              true
+            )
+          ),
+        ]),
+        // emit exit so the trace node records the error as its returnValue
+        this.t.expressionStatement(
+          this.emitTraceEvent(
+            this.getEventDetail(path, state, {
+              type: "exit",
+              fnName,
+              chained: false,
+            })
+          )
+        ),
+        // emit done so activeTraceIdSet is cleaned up without waiting for timeout
+        this.t.expressionStatement(
+          this.emitTraceEvent(
+            this.getEventDetail(path, state, {
+              type: "done",
+              fnName,
+              chained: false,
+            })
+          )
+        ),
+        // Clean up Zone entry on error path to prevent memory leak
         this.t.expressionStatement(
           this.t.unaryExpression(
             "delete",
@@ -1279,7 +1357,8 @@ class ScryAst {
     const callee = path.node.callee;
     let fnName = ANONYMOUS_FUNCTION_NAME;
     if (this.t.isIdentifier(callee)) {
-      fnName = callee.name;
+      // new Foo() → "new Foo", plain call foo() → "foo"
+      fnName = path.isNewExpression() ? `new ${callee.name}` : callee.name;
     } else if (
       this.t.isMemberExpression(callee) &&
       this.t.isIdentifier(callee.property)

--- a/src/babel/scry.check.ts
+++ b/src/babel/scry.check.ts
@@ -1,7 +1,7 @@
 import * as babel from "@babel/core";
 import { Environment } from "../utils/enviroment.js";
 import Extractor from "../utils/extractor.js";
-import { DEVELOPMENT_MODE, TRACE_MARKER, TRACE_ZONE } from "./scry.constant.js";
+import { ACTIVE_TRACE_ID_SET, DEVELOPMENT_MODE, TRACE_MARKER, TRACE_ZONE } from "./scry.constant.js";
 
 //Checkers for scry babel plugin
 class ScryChecker {
@@ -211,9 +211,12 @@ class ScryChecker {
         this.t.isIdentifier(parent.node.left.object.property, {
           name: "root",
         }) &&
-        // this.t.isStringLiteral(parent.node.left.property, {
-        //   value: ACTIVE_TRACE_ID_SET,
-        // }) &&
+        // Re-enabled: narrowed to ACTIVE_TRACE_ID_SET only.
+        // Any Zone.root[x] = new X() was previously skipped; now only the
+        // exact scry-generated initialisation is skipped.
+        this.t.isStringLiteral(parent.node.left.property, {
+          value: ACTIVE_TRACE_ID_SET,
+        }) &&
         parent.node.left.computed
       ) {
         parent.skip();

--- a/src/tracer/export/rumTImeStrategies/NodeStrategy.ts
+++ b/src/tracer/export/rumTImeStrategies/NodeStrategy.ts
@@ -33,7 +33,8 @@ class NodeStrategy implements RuntimeStrategyInterface {
     //Trace end date
     const now = dayjs().format(REPORT_FILE_DATE_FORMAT);
     //File path for result
-    const filePath = `${REPORT_DIR}/${TRACE_RESULT_FILE_NAME}:${now}.${TRACE_RESULT_FILE_EXTENSION}`;
+    // Colon is forbidden in Windows filenames; use underscore as separator.
+    const filePath = `${REPORT_DIR}/${TRACE_RESULT_FILE_NAME}_${now}.${TRACE_RESULT_FILE_EXTENSION}`;
     fs.writeFileSync(filePath, html);
     return filePath;
   }

--- a/src/tracer/format.ts
+++ b/src/tracer/format.ts
@@ -658,12 +658,12 @@ class Format {
           </div>
 
           <script>
-            const items = ${JSON.stringify(
-              flattenNodes(traceNodes),
-              (key, value) => {
-                if (key === "parent") return undefined;
-                return value;
-              }
+            const items = ${Format.safeStringify(
+              flattenNodes(traceNodes).map((n) => {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { parent, ...rest } = n as TraceNode & { parent?: unknown };
+                return rest;
+              })
             )};
             
             function downloadHtml() {
@@ -679,7 +679,6 @@ class Format {
 
             function generateHtmlContent(node) {
               const callType = node.classCode ? "method" : "function";
-              console.log(node)
               return \`
                 <div class="trace-info">
                   <div class="detail-header">

--- a/src/tracer/record/TracerRecorder.ts
+++ b/src/tracer/record/TracerRecorder.ts
@@ -153,6 +153,20 @@ class TraceRecorder implements TraceRecorderInterface {
       globalThis.addEventListener(TRACE_EVENT_NAME, this.boundOnTrace);
     }
   }
+
+  /**
+   * destroy method.
+   * Removes the event listener registered in initEventListener.
+   * Call this in hot-reload / test teardown environments where a new
+   * TraceRecorder instance will be created, to prevent duplicate listeners.
+   */
+  public destroy() {
+    if (Environment.isNodeJS()) {
+      process.off(TRACE_EVENT_NAME, this.boundOnTrace);
+    } else {
+      globalThis.removeEventListener(TRACE_EVENT_NAME, this.boundOnTrace);
+    }
+  }
   /**
    * isAllContextDone method.
    * This method is used to check if all context is done.
@@ -173,6 +187,9 @@ class TraceRecorder implements TraceRecorderInterface {
    * Without a timeout, an unhandled async error can leave traceIds in activeTraceIdSet
    * forever because the "done" event is never emitted, causing this method to hang indefinitely.
    */
+  // Returns true when all contexts finished cleanly, false when the timeout
+  // fired before all done events arrived. Callers (Tracer.end) can use this to
+  // log a warning or annotate the report as potentially incomplete.
   public waitAllContextDone(
     bundleId: number,
     timeout = 5000
@@ -180,12 +197,12 @@ class TraceRecorder implements TraceRecorderInterface {
     return new Promise((resolve) => {
       const start = Date.now();
       const interval = setInterval(() => {
-        if (
-          this.isAllContextDone(bundleId) ||
-          Date.now() - start > timeout
-        ) {
-          resolve(true);
+        if (this.isAllContextDone(bundleId)) {
           clearInterval(interval);
+          resolve(true);
+        } else if (Date.now() - start > timeout) {
+          clearInterval(interval);
+          resolve(false);
         }
       }, WAIT_ALL_CONTEXT_DONE_INTERVAL);
     });

--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -73,9 +73,15 @@ class Tracer {
     //in Promise, return value is resolved when 'then' trigger
     //in Object, return value is resolved automatically when context is done
     const asyncTaskLoading = this.recorder.waitAllContextDone(endBundleId);
-    //Wait for all return values to be resolved
     asyncTaskLoading
-      .then(async () => {
+      .then(async (completed) => {
+        if (!completed) {
+          Output.printError(
+            "Tracer.end(): some async traces did not complete before the timeout. " +
+            "The report may be incomplete. Consider increasing the timeout or " +
+            "ensuring all async operations finish before calling Tracer.end()."
+          );
+        }
         //Get current bundle details
         const currentBundleDetails =
           this.recorder.getBundleMap().get(endBundleId)?.details || [];

--- a/src/utils/extractor.ts
+++ b/src/utils/extractor.ts
@@ -72,7 +72,14 @@ class Extractor {
     if (this.isMethod(instance, method)) {
       const ctor = instance!.constructor as object;
       if (this.methodCache.has(ctor)) {
-        return this.methodCache.get(ctor)!;
+        const cached = this.methodCache.get(ctor)!;
+        // If the current call also resolved a functionCode (from the func path
+        // above), merge it in — returning the cached entry directly would
+        // discard it and leave functionCode empty in the trace detail.
+        if (result.functionCode) {
+          return { ...cached, functionCode: result.functionCode };
+        }
+        return cached;
       }
       result.classCode = this.extractOriginCode(
         instance!.constructor.toString()


### PR DESCRIPTION
## Summary

2차 코드베이스 분석으로 발견한 버그 11개를 수정했습니다.

### 🟠 High

| 파일 | 버그 | 수정 |
|------|------|------|
| `scry.ast.ts` | 동기 예외 시 `activeTraceIdSet`에 traceId가 타임아웃까지 남음, trace 트리 불완전 | catch 블록에 exit/done 이벤트 추가 |
| `scry.ast.ts` | `Zone.root._properties` 전체 교체 → Zone.js 내부 필드 소실 | `Object.assign` 으로 병합 방식 변경 |
| `scry.ast.ts` | `_depth` 읽기를 `Zone.current["_depth"]`로 해서 항상 `undefined` → maxDepth 미동작 | `Zone.current._properties?.["_depth"]` 로 수정 (guard + fork 두 군데) |
| `extractor.ts` | `methodCache` 히트 시 앞서 채운 `functionCode` 무시하고 캐시 반환 | `functionCode` 병합 후 반환 |

### 🟡 Medium

| 파일 | 버그 | 수정 |
|------|------|------|
| `TracerRecorder` | `waitAllContextDone` 타임아웃/정상완료 모두 `true` → 불완전 리포트 감지 불가 | 타임아웃 시 `false`, 정상 시 `true` 반환 |
| `tracer.ts` | 미완성 트레이스 시 경고 없음 | `completed === false` 시 `printError` 추가 |
| `format.ts` | 인라인 `JSON.stringify` 순환참조/BigInt 미처리 | `Format.safeStringify` 로 교체 |
| `scry.check.ts` | `isZoneRootActiveTraceSetInit` 에서 `ACTIVE_TRACE_ID_SET` 값 검사 주석 처리됨 → 무관한 `Zone.root[x] = new X()` 패턴도 계측 누락 | 상수 검사 복원 및 import 추가 |
| `NodeStrategy.ts` | 리포트 파일명에 `:` 사용 → Windows 저장 불가 | `_` 로 변경 |

### 🟢 Low

| 파일 | 버그 | 수정 |
|------|------|------|
| `format.ts` | `console.log(node)` 잔존 | 제거 |
| `TracerRecorder` | 이벤트 리스너 제거 API 없음 → HMR/테스트에서 누적 | `destroy()` 추가 |
| `scry.ast.ts` | `new Foo()` Identifier callee에서 함수명이 `Foo` → `new Foo`여야 함 | `path.isNewExpression()` 분기 추가 |

## Test plan

- [ ] `pnpm run build` 성공
- [ ] 동기 예외 함수 추적 시 리포트에 error returnValue가 표시되는지 확인
- [ ] 재귀 함수에서 maxDepth가 실제로 동작하는지 확인 (이전엔 항상 0으로 읽혀서 미동작)
- [ ] Windows 환경에서 리포트 파일 저장 성공 확인
- [ ] `Tracer.end()` 타임아웃 시 콘솔 경고 출력 확인

Made with [Cursor](https://cursor.com)