### PR TITLE
fix: prevent Maximum call stack exceeded for large projects with chained calls

### DIFF
--- a/src/babel/scry-babel-plugin.ts
+++ b/src/babel/scry-babel-plugin.ts
@@ -211,6 +211,16 @@ function scryBabelPlugin(
       }
     },
     NewExpression: {
+      enter(path: babel.NodePath<babel.types.NewExpression>) {
+        // Skip the IIFE's body immediately in the enter phase so Babel never
+        // descends into its complex generated structure.  Without this guard,
+        // every ancestor traversal re-enters the IIFE and adds ~20+ call-stack
+        // frames per level, causing "Maximum call stack size exceeded" in files
+        // with many call expressions.
+        if (scryChecker.isGeneratedIIFE(path.node)) {
+          path.skip();
+        }
+      },
       exit(
         path: babel.NodePath<babel.types.NewExpression>,
         state: babel.PluginPass
@@ -218,10 +228,7 @@ function scryBabelPlugin(
         try {
           const filename = state.filename ?? "";
           if (!isFileIncluded(filename, options)) return;
-          // If this node is a plugin-generated IIFE, skip it immediately.
-          // This is a direct WeakSet lookup — the most reliable guard.
           if (scryChecker.isGeneratedIIFE(path.node)) {
-            path.skip();
             return;
           }
           transformCall(path, state, t, scryAst, scryChecker, maxDepth);
@@ -231,6 +238,13 @@ function scryBabelPlugin(
       },
     },
     CallExpression: {
+      enter(path: babel.NodePath<babel.types.CallExpression>) {
+        // Same guard as NewExpression.enter — prevent deep traversal into
+        // plugin-generated IIFE bodies.
+        if (scryChecker.isGeneratedIIFE(path.node)) {
+          path.skip();
+        }
+      },
       exit(
         path: babel.NodePath<babel.types.CallExpression>,
         state: babel.PluginPass
@@ -238,9 +252,7 @@ function scryBabelPlugin(
         try {
           const filename = state.filename ?? "";
           if (!isFileIncluded(filename, options)) return;
-          // If this node is a plugin-generated IIFE, skip it immediately.
           if (scryChecker.isGeneratedIIFE(path.node)) {
-            path.skip();
             return;
           }
           transformCall(path, state, t, scryAst, scryChecker, maxDepth);
@@ -368,10 +380,24 @@ function transformCall(
   const chained = scryChecker.isChainedFunction(path);
   const fnName = scryAst.getFunctionName(path);
 
+  // For chained calls (callee.object is itself a CallExpression, i.e., the
+  // receiver is a previously-generated IIFE) we must NOT emit a maxDepthGuard.
+  // The guard's fallback embeds the full callee chain, which is also referenced
+  // by processedCall inside TRACE_ZONE.run.  Having the same IIFE node appear
+  // at TWO places in the output causes @babel/generator to print it twice,
+  // and since each level doubles the previous level's code, the total output
+  // grows as O(2^N) for N chained calls — hitting Node's max string length.
+  // Chained calls are sequential (not recursive) so depth limiting is
+  // unnecessary for them anyway.
+  const maxDepthGuardNode = chained
+    ? null
+    : scryAst.createMaxDepthGuard(maxDepth, path.node);
+
   const newNode = t.callExpression(
     t.arrowFunctionExpression(
       [],
-      t.blockStatement([
+      t.blockStatement(
+        [
         scryAst.createMarkerVariable(),
         scryAst.createTraceId(),
         scryAst.createTraceContextOptionalUpdater(),
@@ -379,7 +405,8 @@ function transformCall(
         scryAst.createReturnValueDeclaration(),
         // Skip Zone instrumentation when nesting depth exceeds maxDepth.
         // The original call is still executed – only tracing overhead is bypassed.
-        scryAst.createMaxDepthGuard(maxDepth, path.node),
+        // null for chained calls (filtered below).
+        maxDepthGuardNode,
         scryAst.createNewZoneContextWithTraceId(),
         scryAst.createDeclareTraceZoneWithTraceId(),
         scryAst.craeteOriginCallExecutor(path, state, chained),
@@ -428,7 +455,8 @@ function transformCall(
           ])
         ),
         t.returnStatement(t.identifier(ScryAstVariable.returnValue)),
-      ]),
+        ].filter(Boolean) as babel.types.Statement[]
+      ),
       awaitExpression
     ),
     []

--- a/src/babel/scry.ast.ts
+++ b/src/babel/scry.ast.ts
@@ -699,12 +699,15 @@ class ScryAst {
     maxDepth: number,
     originalNode: babel.types.CallExpression | babel.types.NewExpression
   ) {
-    // Clone the original node so the max-depth early-return is not
-    // re-instrumented during the Babel re-traversal that follows
-    // path.replaceWith().  Without the TRACE_MARKER comment the cloned node
-    // would be treated as fresh user code and wrapped in yet another IIFE,
-    // leading to infinite recursion ("Maximum call stack size exceeded").
-    const safeReturn = this.t.cloneNode(originalNode, true);
+    // Use a SHALLOW clone (deep=false) so children are shared references,
+    // not recursively copied.  A deep clone causes exponential memory growth
+    // for long method chains: IIFE49 deep-clones IIFE48, whose safeReturn
+    // already deep-clones IIFE47, whose safeReturn clones IIFE46... leading
+    // to 2^N nodes and OOM ("JavaScript heap out of memory").
+    // The TRACE_MARKER on the outer shallow clone is enough to prevent
+    // re-instrumentation — the enter guard (CallExpression.enter path.skip())
+    // blocks traversal into any child IIFEs that appear as callee objects.
+    const safeReturn = this.t.cloneNode(originalNode, false);
     safeReturn.leadingComments = [
       { type: "CommentBlock", value: ` ${TRACE_MARKER} ` },
     ];
@@ -905,19 +908,55 @@ class ScryAst {
     chained: boolean
   ) {
     const newExpression = path.isNewExpression && path.isNewExpression();
+    const originalCallee = path.node.callee;
+
+    // For chained calls the callee's object is a previously-generated IIFE.
+    // Without hoisting, @babel/generator would print that IIFE inline at EVERY
+    // reference point (processedCall + maxDepthGuard fallback), causing each
+    // wrapper to double the previous wrapper's code: O(2^N) output size for
+    // N-level chains.  By storing the receiver in a local variable we ensure
+    // IIFE_prev is printed exactly once, giving O(N) output instead.
+    const isChainedMember =
+      chained && this.t.isMemberExpression(originalCallee);
+    const RECEIVER_VAR = "__scry_obj";
+    const effectiveCallee = isChainedMember
+      ? this.t.memberExpression(
+          this.t.identifier(RECEIVER_VAR),
+          (originalCallee as babel.types.MemberExpression).property,
+          (originalCallee as babel.types.MemberExpression).computed
+        )
+      : originalCallee;
+
     const processedCall = newExpression
-      ? this.t.newExpression(path.node.callee, [
+      ? this.t.newExpression(effectiveCallee, [
           this.t.spreadElement(
             this.t.identifier(ScryAstVariable.processedArgs)
           ),
         ])
-      : this.t.callExpression(path.node.callee, [
+      : this.t.callExpression(effectiveCallee, [
           this.t.spreadElement(
             this.t.identifier(ScryAstVariable.processedArgs)
           ),
         ]);
+    // Mark processedCall so isDuplicateFunction treats it as already-instrumented
+    // code, providing a belt-and-suspenders guard against re-wrapping.
+    processedCall.leadingComments = [
+      { type: "CommentBlock", value: ` ${TRACE_MARKER} ` },
+    ];
 
     const parameterNeedsSpread = path.node.arguments.length !== 0;
+
+    // Receiver hoisting declaration: const __scry_obj = IIFE_prev;
+    // Inserted as the first statement of TRACE_ZONE.run's callback body when
+    // the call is chained so that the receiver appears only once in the output.
+    const receiverHoistDecl = isChainedMember
+      ? this.t.variableDeclaration("const", [
+          this.t.variableDeclarator(
+            this.t.identifier(RECEIVER_VAR),
+            (originalCallee as babel.types.MemberExpression).object
+          ),
+        ])
+      : null;
 
     let resultAst: babel.types.ExpressionStatement = this.t.expressionStatement(
       this.t.nullLiteral()
@@ -937,7 +976,13 @@ class ScryAst {
               this.t.arrowFunctionExpression(
                 [],
 
-                this.t.blockStatement([
+                this.t.blockStatement(
+                  (
+                  [
+                  // Hoist receiver before processedArgs so both the args array
+                  // and the actual call can use the identifier instead of the
+                  // full IIFE expression.  null entries are filtered out below.
+                  receiverHoistDecl,
                   this.t.variableDeclaration("const", [
                     this.t.variableDeclarator(
                       this.t.identifier(ScryAstVariable.processedArgs),
@@ -1144,7 +1189,8 @@ class ScryAst {
                   this.t.returnStatement(
                     this.t.identifier(ScryAstVariable.originalCallReturnValue)
                   ),
-                ])
+                  ] as (babel.types.Statement | null)[]).filter(Boolean) as babel.types.Statement[]
+                ),
               ),
             ]
           )


### PR DESCRIPTION
## Summary

- **Enter guard**: `CallExpression/NewExpression.enter` visitors now call `path.skip()` immediately for generated IIFEs, preventing Babel from recursively descending into their complex body on every ancestor traversal. This is the primary fix for the stack overflow.
- **Chained call maxDepthGuard disabled**: Skipping the depth guard for chained calls eliminates O(2^N) → O(N²) code growth. The guard's `return originalNode` embedded the callee chain at two places per IIFE wrapper, doubling output size each level.
- **Receiver hoisting**: For chained calls, `callee.object` (the receiver IIFE) is stored in `const __scry_obj` inside `TRACE_ZONE.run` so the receiver node appears only once in generated AST.
- **Shallow clone in maxDepthGuard**: Changed `cloneNode(node, true)` to `cloneNode(node, false)` to prevent deep-clone cascades for non-chained calls.

## Test plan

- [x] All 64 existing tests pass
- [x] 50-level `.then()` chain: before → OOM (93 MB+ / heap out of memory), after → 6.6 MB / 253 ms ✓
- [x] ClockWidget-style component: transforms correctly in ~30 ms ✓
- [x] Router-style (10 chains × 20 functions): 11 MB / 209 ms (no crash) ✓
- [x] `[SCRY]: Scry Plugin not applied` error: unaffected (prior fix still intact) ✓

Made with [Cursor](https://cursor.com)