### PR TITLE
fix(plugin): reduce output bloat to prevent stack overflow on large projects

### DIFF
--- a/src/babel/scry-babel-plugin.ts
+++ b/src/babel/scry-babel-plugin.ts
@@ -380,16 +380,19 @@ function transformCall(
   const chained = scryChecker.isChainedFunction(path);
   const fnName = scryAst.getFunctionName(path);
 
-  // For chained calls (callee.object is itself a CallExpression, i.e., the
-  // receiver is a previously-generated IIFE) we must NOT emit a maxDepthGuard.
-  // The guard's fallback embeds the full callee chain, which is also referenced
-  // by processedCall inside TRACE_ZONE.run.  Having the same IIFE node appear
-  // at TWO places in the output causes @babel/generator to print it twice,
-  // and since each level doubles the previous level's code, the total output
-  // grows as O(2^N) for N chained calls — hitting Node's max string length.
-  // Chained calls are sequential (not recursive) so depth limiting is
-  // unnecessary for them anyway.
-  const maxDepthGuardNode = chained
+  // Skip maxDepthGuard whenever the call already contains a previously-
+  // generated IIFE in its callee or arguments.  The guard's `return originalNode`
+  // fallback embeds the full callee + args, and processedCall references the
+  // same nodes again inside TRACE_ZONE.run.  When those nodes are large IIFEs
+  // (chained calls, or any nested call like `f(g(h()))`), printing them twice
+  // doubles the output per nesting level — O(2^N) growth that explodes file
+  // size and overflows the stack downstream (vite/esbuild post-processing).
+  // chained() is the narrow `a().b()` case; hasGeneratedIIFEDescendant() also
+  // catches `f(a())`, `f(g(), h())`, etc.  These calls run sequentially, so
+  // depth limiting is unnecessary for them anyway.
+  const containsGeneratedIIFE =
+    chained || scryChecker.hasGeneratedIIFEDescendant(path.node);
+  const maxDepthGuardNode = containsGeneratedIIFE
     ? null
     : scryAst.createMaxDepthGuard(maxDepth, path.node);
 

--- a/src/babel/scry.ast.ts
+++ b/src/babel/scry.ast.ts
@@ -1286,8 +1286,22 @@ class ScryAst {
   }
 
   //Create emit trace event ast object
+  //
+  // Wraps the detail object in a one-shot IIFE so the (potentially huge) detail
+  // expression is emitted exactly ONCE per trace event instead of being printed
+  // verbatim in both the Node.js and Browser branches.  Before this change, every
+  // CallExpression that scry instrumented produced 4–8 copies of the detail
+  // object (sync enter/exit + async then/catch enter/exit, each duplicated for
+  // Node and Browser), causing 100×+ output bloat for ordinary files and
+  // overflowing the call stack in vite/esbuild downstream processing.
+  //
+  // Generated form:
+  //   ((d) => typeof window === "undefined"
+  //     ? process.emit(NAME, { detail: d })
+  //     : globalThis.dispatchEvent(new CustomEvent(NAME, { detail: d })))(<detail>)
   public emitTraceEvent(detail: babel.types.ObjectExpression) {
-    return this.t.conditionalExpression(
+    const D = this.t.identifier("d");
+    const branch = this.t.conditionalExpression(
       this.t.binaryExpression(
         "===",
         this.t.unaryExpression("typeof", this.t.identifier("window")),
@@ -1302,7 +1316,7 @@ class ScryAst {
         [
           this.t.stringLiteral(TRACE_EVENT_NAME),
           this.t.objectExpression([
-            this.t.objectProperty(this.t.identifier("detail"), detail),
+            this.t.objectProperty(this.t.identifier("detail"), D),
           ]),
         ]
       ),
@@ -1316,11 +1330,15 @@ class ScryAst {
           this.t.newExpression(this.t.identifier("CustomEvent"), [
             this.t.stringLiteral(TRACE_EVENT_NAME),
             this.t.objectExpression([
-              this.t.objectProperty(this.t.identifier("detail"), detail),
+              this.t.objectProperty(this.t.identifier("detail"), D),
             ]),
           ]),
         ]
       )
+    );
+    return this.t.callExpression(
+      this.t.arrowFunctionExpression([this.t.identifier("d")], branch),
+      [detail]
     );
   }
 

--- a/src/babel/scry.check.ts
+++ b/src/babel/scry.check.ts
@@ -317,6 +317,56 @@ class ScryChecker {
     );
   }
 
+  /**
+   * Returns true when this call has a previously-generated IIFE somewhere in
+   * its callee chain or argument list.  Such calls must NOT receive a
+   * createMaxDepthGuard fallback because the guard's `return originalNode`
+   * embeds the entire (already-wrapped) callee/args, causing the same large
+   * IIFE node to be printed twice — once in the guard, once in processedCall.
+   * For deeply-nested or chained code this doubles output per level (O(2^N)).
+   *
+   * isChainedFunction only catches `a().b()` (callee.object is a Call); this
+   * helper additionally catches `f(a())` and `f(g(h()))` where the wrapped
+   * IIFE lives inside arguments.
+   */
+  public hasGeneratedIIFEDescendant(
+    node: babel.types.CallExpression | babel.types.NewExpression
+  ): boolean {
+    const visit = (n: babel.types.Node | null | undefined): boolean => {
+      if (!n) return false;
+      if (
+        (this.t.isCallExpression(n) || this.t.isNewExpression(n)) &&
+        this._generatedIIFENodes.has(n)
+      ) {
+        return true;
+      }
+      // Only descend through expression-bearing children we care about.
+      if (this.t.isMemberExpression(n)) {
+        return visit(n.object) || (n.computed && visit(n.property));
+      }
+      if (this.t.isCallExpression(n) || this.t.isNewExpression(n)) {
+        if (visit(n.callee)) return true;
+        for (const a of n.arguments) {
+          if (this.t.isSpreadElement(a)) {
+            if (visit(a.argument)) return true;
+          } else if (visit(a as babel.types.Node)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    };
+    if (visit(node.callee)) return true;
+    for (const a of node.arguments) {
+      if (this.t.isSpreadElement(a)) {
+        if (visit(a.argument)) return true;
+      } else if (visit(a as babel.types.Node)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   //Check if the function is a pre-processed function
   public isDuplicateFunction(
     path: babel.NodePath<babel.types.CallExpression | babel.types.NewExpression>


### PR DESCRIPTION
## Summary

When applying the plugin to a real-world Vite + React + emotion project (~340 .tsx files), simple hook-heavy files expanded **~600×** (e.g. a 4 KB `useState` file → 2.4 MB output).  Downstream tools (vite:react-babel sourcemap merge / esbuild) then hit:

```
Maximum call stack size exceeded
  Plugin: vite:react-babel
```

Two compounding causes:

- **Duplicated `detail` object in `emitTraceEvent`** — the entire ~30-property detail literal was inlined in both the Node.js (`process.emit`) and Browser (`globalThis.dispatchEvent`) branches, repeated 4–8 times per traced call (sync enter/exit + async then/catch enter/exit). Wrapped in a one-shot arrow IIFE so the detail is emitted exactly once.
- **`createMaxDepthGuard` fallback embedded already-wrapped IIFEs** — previously skipped only for `a().b()` chains, but the same O(2^N) growth applies to any nested call (`f(g())`, `f(g(), h())`). Added `hasGeneratedIIFEDescendant()` to detect this generally and skip the guard accordingly. Such calls are sequential, not recursive, so depth limiting was never needed for them.

## Test plan

- [x] All 64 plugin unit tests pass (`pnpm test`)
- [x] Type-check clean (`tsc --noEmit`)
- [x] Bulk-transformed all 336 .ts/.tsx files of the failing real-world project — 0 failures, total output reduced ~35% with `NODE_ENV=development`
- [x] `useViewport.tsx` (the smallest reproducer): 580 B → 244 KB (before) → 156 KB (after)
- [ ] User to verify Vite no longer reports "Maximum call stack size exceeded" on the original Funnel.tsx repro

🤖 Generated with [Claude Code](https://claude.com/claude-code)