### PR TITLE
chore(docs): import .cursor/rules into CLAUDE.md via @-syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,11 @@
 
 Scry is a JavaScript/TypeScript execution flow tracer that instruments code at **compile time** (Babel AST plugin) and collects call graphs at **runtime** (Zone.js + event system).
 
-> **Rule files** (also used by Cursor — read these for detailed conventions):
-> - [.cursor/rules/project-overview.mdc](.cursor/rules/project-overview.mdc) — project structure, core constraints, build commands
-> - [.cursor/rules/babel-plugin.mdc](.cursor/rules/babel-plugin.mdc) — generated IIFE structure, AST authoring rules, skip conditions
-> - [.cursor/rules/git-workflow.mdc](.cursor/rules/git-workflow.mdc) — branch strategy, commit/PR procedure, safety rules
+> **Rule files** — single source of truth in `.cursor/rules/`, shared by Cursor (`alwaysApply: true`) and Claude Code (`@`-imports below).
+>
+> @.cursor/rules/project-overview.mdc
+> @.cursor/rules/babel-plugin.mdc
+> @.cursor/rules/git-workflow.mdc
 
 ---
 


### PR DESCRIPTION
## Summary

Cursor auto-loads `.cursor/rules/*.mdc` via `alwaysApply: true` in each file's frontmatter. Claude Code has no equivalent auto-loader — previously it only saw markdown links to those files and had to `Read` them on demand.

Switch the references in [CLAUDE.md](CLAUDE.md) to Claude Code's `@`-import syntax so the same rule files are loaded into context at session start, without duplication. Single source of truth remains `.cursor/rules/`; both tools now consume the same files.

## Test plan

- [x] Diff is the four references only — no rule content moved
- [ ] Open a fresh Claude Code session at the repo root and confirm the babel/git rules are accessible without an explicit `Read`

🤖 Generated with [Claude Code](https://claude.com/claude-code)