### PR TITLE
fix: instrument when NODE_ENV is undefined (Vite dev) + empty-tree diagnostic

### DIFF
--- a/src/babel/scry.check.ts
+++ b/src/babel/scry.check.ts
@@ -1,6 +1,6 @@
 import * as babel from "@babel/core";
 import Extractor from "../utils/extractor.js";
-import { ACTIVE_TRACE_ID_SET, DEVELOPMENT_MODE, TRACE_MARKER, TRACE_ZONE } from "./scry.constant.js";
+import { ACTIVE_TRACE_ID_SET, TRACE_MARKER, TRACE_ZONE } from "./scry.constant.js";
 
 //Checkers for scry babel plugin
 class ScryChecker {
@@ -298,11 +298,24 @@ class ScryChecker {
   //Check if the environment is development. Called at Babel transform time (always Node.js context).
   //The isNodeJS() guard was removed because bundlers like Vite can expose a window object in their
   //build context, causing the check to incorrectly return false for browser-targeted builds.
+  //
+  // Important: Vite's dev server does NOT always set process.env.NODE_ENV at
+  // the time our plugin's transform hook runs (it's set late, in some entry
+  // paths it's `undefined`).  Anything that isn't *explicitly* "production"
+  // is treated as development — that's the only case we want to skip.
+  // Real-world impact of the strict check: instrumentation silently no-op'd
+  // in user Vite projects, producing an empty trace report
+  // ("__INJECTION_DATA__" = "[[]]" / `data.length === 0`).
   static isDevelopmentMode() {
     if (typeof process !== "undefined" && process.env) {
-      return process.env.NODE_ENV === DEVELOPMENT_MODE;
+      const v = process.env.NODE_ENV;
+      // Treat anything other than the explicit "production" string as dev.
+      // This covers undefined, "" , "development", "dev", "test", etc.
+      return v !== "production";
     }
-    return false;
+    // No `process` (very unusual at babel transform time): assume dev so the
+    // user gets traces rather than a confusing empty report.
+    return true;
   }
 
   //Check if the function is a chained function

--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -103,6 +103,24 @@ class Tracer {
         //Get current bundle details
         const currentBundleDetails =
           this.recorder.getBundleMap().get(endBundleId)?.details || [];
+        // Surface the empty-tree case loudly so users don't stare at a
+        // "No traced calls were recorded" page wondering whether the plugin
+        // is broken.  The most common real cause is "the function I wrapped
+        // in start/end never actually got called during this trace window"
+        // — e.g. a probabilistic spawn inside setInterval.  Other possible
+        // causes (NODE_ENV not set to development at transform time, stale
+        // .vite/deps prebundle, plugin not in vite babel.plugins, etc.) are
+        // also worth flagging here.
+        if (currentBundleDetails.length === 0) {
+          Output.printError(
+            "Tracer.end(): no events were recorded for this bundle. " +
+              "Common causes: (1) the traced function was not invoked between " +
+              "Tracer.start() and Tracer.end(); (2) NODE_ENV !== 'development' " +
+              "at transform time; (3) the babel plugin is not active for this " +
+              "file; (4) Vite served a stale .vite/deps prebundle (try " +
+              "`rm -rf node_modules/.vite`)."
+          );
+        }
         //Make trace tree(hierarchical tree structure by call)
         const traceNodes: TraceNode[] =
           this.nodeGenerator.generateNodesWithTraceDetails(currentBundleDetails);

--- a/tests/integration/userScenario.test.ts
+++ b/tests/integration/userScenario.test.ts
@@ -167,6 +167,31 @@ describe("Integration: browser emit path", () => {
       (globalThis as Record<string, unknown>).addEventListener = origAddListener;
   });
 
+  // Regression: `isDevelopmentMode` used to require NODE_ENV === "development"
+  // exactly, which silently disabled the plugin in setups where Vite's dev
+  // server hadn't set it (the common real-world case — user reported an
+  // empty __INJECTION_DATA__ === "[[]]" because Math.* never got wrapped).
+  // Anything *not* explicitly "production" is now treated as dev.
+  it("treats NODE_ENV undefined / '' / 'test' as development", async () => {
+    const { default: ScryChecker } = await import(
+      "../../src/babel/scry.check.js"
+    );
+    const orig = process.env.NODE_ENV;
+    try {
+      delete process.env.NODE_ENV;
+      expect(ScryChecker.isDevelopmentMode()).toBe(true);
+      process.env.NODE_ENV = "";
+      expect(ScryChecker.isDevelopmentMode()).toBe(true);
+      process.env.NODE_ENV = "test";
+      expect(ScryChecker.isDevelopmentMode()).toBe(true);
+      process.env.NODE_ENV = "production";
+      expect(ScryChecker.isDevelopmentMode()).toBe(false);
+    } finally {
+      if (orig === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = orig;
+    }
+  });
+
   it("isNodeJS does not return true when only `process` polyfill is present", () => {
     // Simulate Vite's `define: { "process.env.NODE_ENV": ... }` which exposes
     // process but no real Node runtime, alongside a window.  Previously this

--- a/webUI/src/App.tsx
+++ b/webUI/src/App.tsx
@@ -4,6 +4,7 @@ import { useInjectionMeta } from "./hooks/useInjectionMeta";
 import { Header } from "./components/Header";
 import { TraceList } from "./components/TraceList";
 import { NodeDetailModal } from "./components/NodeDetailModal";
+import { EmptyDiagnostic } from "./components/EmptyDiagnostic";
 import type { TraceNode } from "./types/injection";
 import "./App.css";
 
@@ -12,8 +13,10 @@ function App() {
   const { meta } = useInjectionMeta();
   const [selected, setSelected] = useState<TraceNode | null>(null);
 
-  // Roots: nodes that are not children of any other node.  flatted
-  // round-trips parent references, so we trust them when present.
+  // Tracer.end() already feeds us a list of roots (the node generator only
+  // pushes nodes whose parentTraceId can't be resolved into the result).
+  // We still defensively filter in case future code paths inject the full
+  // tree — flatted round-trips parent refs, so this stays correct.
   const roots = useMemo(() => {
     const haveParent = data.some((n) => n.parent);
     return haveParent ? data.filter((n) => !n.parent) : data;
@@ -28,10 +31,7 @@ function App() {
       />
       <main className="main">
         {roots.length === 0 ? (
-          <div className="empty">
-            No traced calls were recorded between{" "}
-            <code>Tracer.start()</code> and <code>Tracer.end()</code>.
-          </div>
+          <EmptyDiagnostic data={data} />
         ) : (
           <TraceList nodes={roots} onSelect={setSelected} />
         )}

--- a/webUI/src/components/EmptyDiagnostic.tsx
+++ b/webUI/src/components/EmptyDiagnostic.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import type { TraceNode } from "../types/injection";
+
+interface Props {
+  data: TraceNode[];
+}
+
+// Shown when Tracer.end() produced zero root trace nodes.  Surfaces the raw
+// injection so users can self-diagnose instead of staring at a vague
+// "nothing recorded" message — there are several distinct failure modes:
+//
+//   • Tracer.start/end window contained no instrumented calls (e.g. wrong
+//     NODE_ENV, plugin not actually transforming the file).
+//   • The traced function was never invoked while the window was open
+//     (e.g. probabilistic spawn that never fired in a short session).
+//   • Vite served a stale .vite/deps prebundle that doesn't include the
+//     latest scry runtime listener — emits dispatched but were never heard.
+//   • The bundler tree-shook the side-effect import and the recorder
+//     never registered (despite our package.json sideEffects allow-list).
+export function EmptyDiagnostic({ data }: Props) {
+  const [showRaw, setShowRaw] = useState(false);
+  const raw =
+    typeof window !== "undefined" && typeof window.__INJECTION_DATA__ === "string"
+      ? window.__INJECTION_DATA__
+      : "(no __INJECTION_DATA__ on window)";
+  const meta =
+    typeof window !== "undefined" && (window as unknown as { __INJECTION_META__?: unknown }).__INJECTION_META__;
+
+  return (
+    <div className="empty">
+      <p>
+        No traced calls were recorded between <code>Tracer.start()</code>{" "}
+        and <code>Tracer.end()</code>.
+      </p>
+      <p style={{ marginTop: "1rem", fontSize: "0.9rem" }}>
+        Common causes:
+      </p>
+      <ul style={{ textAlign: "left", maxWidth: "640px", margin: "0.5rem auto", color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+        <li>
+          The traced body had no instrumented call sites — e.g. only{" "}
+          <code>const</code> assignments and literals between{" "}
+          <code>start</code> and <code>end</code>.
+        </li>
+        <li>
+          The traced function (or this code path) wasn't invoked during the
+          window — common for probabilistic branches like{" "}
+          <code>{"if (Math.random() < 0.03) spawn()"}</code>.
+        </li>
+        <li>
+          <code>NODE_ENV</code> was not <code>"development"</code> when the
+          plugin transformed the file — instrumentation is gated on it.
+        </li>
+        <li>
+          Vite served a stale{" "}
+          <code>node_modules/.vite/deps</code> prebundle. Try{" "}
+          <code>rm -rf node_modules/.vite</code> and restart dev.
+        </li>
+      </ul>
+      <p style={{ marginTop: "1rem", fontSize: "0.85rem" }}>
+        Diagnostic — <code>data.length</code>: <strong>{data.length}</strong>
+        {" · "}
+        meta:{" "}
+        <strong>{meta ? "present" : "missing"}</strong>
+      </p>
+      <button
+        type="button"
+        className="header-link"
+        style={{ marginTop: "0.75rem" }}
+        onClick={() => setShowRaw((v) => !v)}
+      >
+        {showRaw ? "Hide" : "Show"} raw __INJECTION_DATA__
+      </button>
+      {showRaw && (
+        <pre
+          style={{
+            marginTop: "0.75rem",
+            textAlign: "left",
+            maxWidth: "100%",
+            overflow: "auto",
+            background: "rgba(0,0,0,0.35)",
+            border: "1px solid var(--card-border)",
+            borderRadius: "10px",
+            padding: "0.85rem 1rem",
+            fontSize: "0.75rem",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-all",
+          }}
+        >
+          {raw.length > 4000 ? raw.slice(0, 4000) + "\n…(truncated)" : raw}
+        </pre>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Two follow-up commits that didn't make it into PR #38 before merge.

### 1. Plugin no longer requires `NODE_ENV === "development"` (real-world bug)

User reported an empty trace report: `__INJECTION_DATA__` decoded to `"[[]]"` (zero details) and an obvious `test()` call right after `Tracer.start()` was nowhere in the tree.

Root cause: `isDevelopmentMode` gated instrumentation on `process.env.NODE_ENV === "development"` *exactly*.  Vite's dev server doesn't always set `NODE_ENV` to `"development"` by the time the babel plugin's transform hook runs (it's set late in some entry paths, undefined in others).  Strict equality failed → every CallExpression skipped → silent empty trace.

Flip the polarity: treat anything **not** explicitly `"production"` as dev.  Now ships traces in:
- Vite dev (`NODE_ENV` undefined),
- vitest test runs (`NODE_ENV="test"`),
- regular Node + ts-node + babel-node (no env set),

and continues to no-op only in `"production"` builds.

### 2. WebUI empty-tree diagnostic

The bare "No traced calls were recorded" page was opaque — users hit it for several distinct reasons.  New `EmptyDiagnostic` panel surfaces:
- `data.length` and whether `__INJECTION_META__` arrived,
- a checklist of common causes (no instrumented calls, function never invoked, wrong NODE_ENV, stale `.vite/deps`),
- a toggle to inspect the raw `__INJECTION_DATA__` string (which is exactly how this PR's root cause was diagnosed — `"W1tdXQ=="` → `"[[]]"`).

`Tracer.end()` also calls `Output.printError` when a bundle's details array is empty, with the same checklist — pings the console even before the user opens the report tab.

## Test plan

- [x] `pnpm test` — 75 → **76 tests** (added NODE_ENV regression).
- [x] `pnpm run build` + WebUI build — clean (215.96 kB embedded).
- [ ] User to repack & retest in the failing Vite project (NODE_ENV unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)