### PR TITLE
feat: dedicated Vite plugin (root cause of recurring empty-trace bug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "import": "./dist/esm/babel/index.js",
       "require": "./dist/cjs/babel/index.cjs"
     },
+    "./vite": {
+      "import": "./dist/esm/vite/index.js",
+      "require": "./dist/cjs/vite/index.cjs"
+    },
     "./zone": {
       "import": "./dist/esm/zone-init.js",
       "require": "./dist/cjs/zone-init.cjs"
@@ -95,5 +99,11 @@
     "flatted": "3.3.3",
     "js-base64": "^3.7.7",
     "zone.js": "^0.15.1"
+  },
+  "peerDependencies": {
+    "vite": ">=4"
+  },
+  "peerDependenciesMeta": {
+    "vite": { "optional": true }
   }
 }

--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -133,6 +133,22 @@ class Tracer {
           //   different globalThis objects (rare; usually a Vite
           //   `optimizeDeps` quirk — try `optimizeDeps.exclude:
           //   ["@racgoo/scry"]`).
+          // rawEvents=0 + pluginApplied=true is the classic "scry runtime
+          // is loaded, but the user's source files were never transformed"
+          // signature.  The most reliable fix is to use the dedicated Vite
+          // plugin instead of trying to wedge the babel plugin into
+          // @vitejs/plugin-react's babel pipeline (which silently no-ops
+          // in many real configs).
+          const transformLikelyMissing =
+            r._rawEventCount === 0 &&
+            (globalThis as { scryPluginApplied?: boolean })
+              .scryPluginApplied === true;
+          const transformHint = transformLikelyMissing
+            ? " ★ Most likely cause: your source files are NOT being transformed by the scry babel plugin (rawEvents=0 + pluginApplied=true). " +
+              "Switch your vite.config to use the dedicated Vite plugin: " +
+              "`import { scryVitePlugin } from \"@racgoo/scry/vite\"; export default { plugins: [scryVitePlugin(), react()] }`. " +
+              "It transforms .ts/.tsx/.js/.jsx directly and is independent of @vitejs/plugin-react's babel config."
+            : "";
           Output.printError(
             "Tracer.end(): no events were recorded for this bundle. " +
               "Common causes: (1) the traced function was not invoked between " +
@@ -142,6 +158,7 @@ class Tracer {
               "`rm -rf node_modules/.vite` and restart dev); " +
               "(5) emit & listener live on different `globalThis` objects " +
               "(try Vite `optimizeDeps.exclude: [\"@racgoo/scry\"]`)." +
+              transformHint +
               diag
           );
         }

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -1,0 +1,118 @@
+// Drop-in Vite plugin that runs the scry babel transform on user source
+// files (.js / .jsx / .ts / .tsx).  Replaces the previous
+// `react({ babel: { plugins: [scryBabelPlugin] } })` instruction in our
+// README, which silently no-op'd in real-world setups whenever:
+//   - the user already had a custom babel.config in the project,
+//   - @vitejs/plugin-react ran some plugins in a different phase,
+//   - or the user simply forgot to wire it through `react.babel.plugins`.
+//
+// Using this plugin instead, the transform is registered DIRECTLY with
+// Vite — independent of @vitejs/plugin-react — and is therefore
+// applied unconditionally.
+
+import type { Plugin } from "vite";
+import { transformSync } from "@babel/core";
+import {
+  scryBabelPluginAutoDetect,
+  type ScryPluginOptions,
+} from "../babel/scry-babel-plugin.js";
+
+const DEFAULT_INCLUDE_RE =
+  /\.(?:tsx?|jsx?|mjs|cjs)(?:\?[^/]*)?$/;
+
+const DEFAULT_EXCLUDE_RE =
+  /(?:^|\/)(?:node_modules|\.vite|dist|build)(?:\/|$)/;
+
+export interface ScryVitePluginOptions
+  extends Omit<ScryPluginOptions, "exclude"> {
+  /**
+   * Override the file inclusion regex.  Default matches .ts/.tsx/.js/.jsx
+   * (with or without query string).
+   */
+  test?: RegExp;
+  /**
+   * Override the file exclusion regex, OR a list of substring matches.
+   * Default skips node_modules / .vite / dist / build.
+   */
+  exclude?: RegExp | string[];
+  /**
+   * Forwarded to the babel plugin's own `exclude` option (substring match
+   * against file paths, evaluated AFTER the regex includes/excludes above).
+   */
+  babelExclude?: string[];
+}
+
+export function scryVitePlugin(options: ScryVitePluginOptions = {}): Plugin {
+  const include = options.test ?? DEFAULT_INCLUDE_RE;
+  const exclude =
+    options.exclude instanceof RegExp ? options.exclude : DEFAULT_EXCLUDE_RE;
+  const stringExcludes =
+    Array.isArray(options.exclude) ? options.exclude : [];
+  const babelOptions: ScryPluginOptions = {
+    include: options.include,
+    exclude: options.babelExclude,
+    maxDepth: options.maxDepth,
+  };
+
+  return {
+    name: "scry-babel",
+    // Run BEFORE @vitejs/plugin-react so it sees the wrapped IIFEs and
+    // can do its own JSX transform on top.  enforce:"pre" puts us in the
+    // "pre" phase Vite runs before any default user-plugin transforms.
+    enforce: "pre",
+    transform(code, id) {
+      // Strip query string so the regex actually matches.
+      const cleanId = id.split("?")[0];
+
+      if (!include.test(cleanId)) return null;
+      if (exclude instanceof RegExp && exclude.test(cleanId)) return null;
+      if (stringExcludes.some((p) => cleanId.includes(p))) return null;
+
+      // The plugin's own NODE_ENV check treats anything-not-"production"
+      // as development.  Force "development" here for safety so that
+      // even ambient process.env.NODE_ENV === "production" inside a
+      // dev-mode invocation doesn't accidentally disable the transform.
+      // The user can opt out by setting their own production build.
+      const wasProd = process.env.NODE_ENV === "production";
+      const orig = process.env.NODE_ENV;
+      if (!wasProd) process.env.NODE_ENV = "development";
+      let result: ReturnType<typeof transformSync>;
+      // Tell babel's parser about TS/JSX directly via parserOpts so we
+      // don't have to depend on @babel/preset-typescript being installed
+      // in the user's project.  We never need to *strip* types — Vite's
+      // esbuild step handles that downstream — we just need babel to
+      // PARSE without choking on `:` annotations and `<Comp />` syntax.
+      const isTS = /\.tsx?(?:\?|$)/.test(cleanId);
+      const isJSX = /\.[jt]sx(?:\?|$)/.test(cleanId);
+      const parserPlugins: string[] = [];
+      if (isTS) parserPlugins.push("typescript");
+      if (isJSX) parserPlugins.push("jsx");
+      try {
+        result = transformSync(code, {
+          filename: cleanId,
+          parserOpts: {
+            sourceType: "module",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            plugins: parserPlugins as any,
+          },
+          generatorOpts: {
+            // Preserve types in the output — esbuild strips them later.
+            // (Not actually used unless babel needs to print TS nodes,
+            // but harmless and future-proof.)
+          },
+          plugins: [[scryBabelPluginAutoDetect, babelOptions]],
+          babelrc: false,
+          configFile: false,
+          sourceMaps: true,
+          sourceType: "module",
+        });
+      } finally {
+        process.env.NODE_ENV = orig;
+      }
+      if (!result?.code) return null;
+      return { code: result.code, map: result.map ?? null };
+    },
+  };
+}
+
+export default scryVitePlugin;

--- a/tests/integration/vitePlugin.test.ts
+++ b/tests/integration/vitePlugin.test.ts
@@ -1,0 +1,136 @@
+// Verifies the dedicated Vite plugin (`@racgoo/scry/vite`) actually
+// transforms .js / .jsx / .ts / .tsx without requiring the user to
+// have @babel/preset-typescript installed — the failure mode that
+// prompted us to ship this plugin in the first place.
+import { describe, it, expect } from "vitest";
+import { scryVitePlugin } from "../../src/vite/index.js";
+
+interface TransformReturn {
+  code: string;
+  map: unknown;
+}
+
+function callTransform(
+  plugin: ReturnType<typeof scryVitePlugin>,
+  code: string,
+  id: string
+): TransformReturn | null {
+  const t = plugin.transform;
+  if (!t || typeof t !== "function") throw new Error("no transform fn");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = (t as any).call({}, code, id);
+  return result as TransformReturn | null;
+}
+
+describe("Vite plugin: scryVitePlugin", () => {
+  const plugin = scryVitePlugin();
+
+  it("transforms a .jsx file (the original empty-trace bug case)", () => {
+    const out = callTransform(
+      plugin,
+      `
+        import { useState } from "react";
+        function App() {
+          const test = () => { console.log("hi"); };
+          test();
+          Math.floor(Math.random() * 3);
+          return null;
+        }
+        export default App;
+      `,
+      "/project/src/App.jsx"
+    );
+    expect(out).not.toBeNull();
+    // The wrapped IIFE marker must appear — proves the babel plugin ran.
+    expect(out!.code).toContain("__SCRY_MARK__");
+    expect(out!.code).toContain("TRACE_ZONE");
+  });
+
+  it("transforms a .tsx file without @babel/preset-typescript installed", () => {
+    const out = callTransform(
+      plugin,
+      `
+        type Props = { a: number };
+        export function f(p: Props): number {
+          return Math.floor(Math.random() * p.a);
+        }
+      `,
+      "/project/src/Comp.tsx"
+    );
+    expect(out).not.toBeNull();
+    expect(out!.code).toContain("__SCRY_MARK__");
+  });
+
+  it("transforms a plain .ts file", () => {
+    const out = callTransform(
+      plugin,
+      `
+        export function add(a: number, b: number): number {
+          return a + b;
+        }
+        add(1, 2);
+      `,
+      "/project/src/util.ts"
+    );
+    expect(out).not.toBeNull();
+    expect(out!.code).toContain("__SCRY_MARK__");
+  });
+
+  it("skips node_modules", () => {
+    const out = callTransform(
+      plugin,
+      `function f() { Math.random(); }`,
+      "/project/node_modules/some-pkg/index.js"
+    );
+    expect(out).toBeNull();
+  });
+
+  it("skips .vite cache", () => {
+    const out = callTransform(
+      plugin,
+      `function f() { Math.random(); }`,
+      "/project/node_modules/.vite/deps/foo.js"
+    );
+    expect(out).toBeNull();
+  });
+
+  it("skips files outside the include regex", () => {
+    const out = callTransform(
+      plugin,
+      `body { color: red; }`,
+      "/project/src/App.css"
+    );
+    expect(out).toBeNull();
+  });
+
+  it("strips query strings before matching extensions (Vite passes ?v=...)", () => {
+    const out = callTransform(
+      plugin,
+      `Math.random();`,
+      "/project/src/A.jsx?v=abc123"
+    );
+    expect(out).not.toBeNull();
+    expect(out!.code).toContain("__SCRY_MARK__");
+  });
+
+  it("respects a custom test regex", () => {
+    const onlyMjs = scryVitePlugin({ test: /\.mjs(?:\?|$)/ });
+    expect(callTransform(onlyMjs, "Math.random();", "/x.jsx")).toBeNull();
+    expect(callTransform(onlyMjs, "Math.random();", "/x.mjs")).not.toBeNull();
+  });
+
+  it("respects substring excludes via options.exclude", () => {
+    const customExcludes = scryVitePlugin({ exclude: ["/legacy/"] });
+    expect(
+      callTransform(customExcludes, "Math.random();", "/project/src/legacy/foo.tsx")
+    ).toBeNull();
+    expect(
+      callTransform(customExcludes, "Math.random();", "/project/src/main.tsx")
+    ).not.toBeNull();
+  });
+
+  it("plugin object has enforce='pre' so it runs before plugin-react", () => {
+    expect(plugin.name).toBe("scry-babel");
+    expect(plugin.enforce).toBe("pre");
+  });
+});

--- a/webUI/src/components/EmptyDiagnostic.tsx
+++ b/webUI/src/components/EmptyDiagnostic.tsx
@@ -41,10 +41,17 @@ export function EmptyDiagnostic({ data, meta }: Props) {
   const d = meta.droppedNullBundle;
   const verdict =
     r === undefined
-      ? "diagnostics not available (older runtime)"
+      ? "Diagnostics not available (older runtime)."
       : r === 0
-      ? meta.listenerKind === "globalThis"
-        ? "Listener registered but received 0 events. Likely cause: emit and listener live on different `globalThis` objects (Vite prebundle), OR no IIFEs were generated at transform time. Try `optimizeDeps.exclude: [\"@racgoo/scry\"]` in vite.config and `rm -rf node_modules/.vite`."
+      ? meta.pluginApplied
+        ? // The most common real-world failure: scry runtime is loaded
+          // (pluginApplied=true) but the user's source files were never
+          // wrapped in IIFEs by the babel plugin.  This usually means
+          // `@vitejs/plugin-react`'s babel config didn't end up running
+          // scryBabelPlugin (custom babel.config.js, plugin order, etc).
+          'Your source files are NOT being transformed by the scry babel plugin (rawEvents=0 but pluginApplied=true). The most reliable fix is to use the dedicated Vite plugin instead of routing through @vitejs/plugin-react: \n\nimport { scryVitePlugin } from "@racgoo/scry/vite";\nexport default { plugins: [scryVitePlugin(), react()] };\n\nThen: rm -rf node_modules/.vite && restart dev.'
+        : meta.listenerKind === "globalThis"
+        ? "Listener registered but received 0 events AND pluginApplied=false. The scry runtime probably never evaluated — check that `@racgoo/scry` is actually imported."
         : "Listener never registered. Tracer module probably never evaluated."
       : r > 0 && d === r
       ? "Listener heard events but every one had traceBundleId=null. Tracer.start() likely wasn't called in the same execution path, or zone propagation broke."


### PR DESCRIPTION
## Summary

The empty-trace bug had a final smoking gun in the user's last log:

```
[diagnostics: rawEvents=0 droppedNullBundle=0 listener=globalThis pluginApplied=true]
App.jsx:27 test
```

`App.jsx:27` — the **original** line number, unchanged.  Which means `App.jsx` was never wrapped in scry's IIFEs.  scry runtime was loaded (`pluginApplied=true`), the listener was registered (`listener=globalThis`), but no source files emitted because the babel plugin never ran on them.

The standard `react({ babel: { plugins: [scryBabelPlugin] } })` recipe in our README silently no-ops in several real configs:
- the user has a project `babel.config.js` → `@vitejs/plugin-react` skips its own `babel.plugins`,
- or the user forgot to add the plugin there,
- or plugin-react ran in a different phase and didn't see it.

## Fix: dedicated Vite plugin

```js
// vite.config.js
import { scryVitePlugin } from "@racgoo/scry/vite";
import react from "@vitejs/plugin-react";

export default {
  plugins: [scryVitePlugin(), react()],
};
```

Registers a Vite `transform` hook with `enforce: "pre"`, runs the scry babel plugin directly on `.ts/.tsx/.js/.jsx`, independent of plugin-react.

Babel's parser uses `parserOpts.plugins = ["typescript", "jsx"]` — the user does NOT need `@babel/preset-typescript` installed.

## Diagnostic upgrade

`Tracer.end()` now detects the `rawEvents=0 + pluginApplied=true` signature and prints a ★ one-shot hint pointing at the Vite plugin.  The WebUI's `EmptyDiagnostic` panel shows the same verdict in big text.

## Tests

10 new tests covering: `.jsx`, `.tsx`, `.ts`, `node_modules` skip, `.vite/deps` skip, non-JS files (`.css`) skip, `?v=...` query strings, custom `test`/`exclude`, `enforce: 'pre'`.

77 → **87 tests** all green.

`vite` declared as an optional peerDependency.

## Test plan

- [x] `pnpm test` — 87/87 pass.
- [x] `pnpm run build` clean (esm + cjs + zone bundle).
- [x] Live test in a fresh React+Vite app with a `.jsx` file: 0 instrumentation lines without the plugin → 80+ instrumentation lines with it.
- [ ] User to switch their `vite.config.js` to use `scryVitePlugin()` and confirm the report HTML actually contains data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)